### PR TITLE
dom0-block-device: Make service start after backend is ready

### DIFF
--- a/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-extended/dom0-block-device/dom0-block-device.bb
+++ b/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-extended/dom0-block-device/dom0-block-device.bb
@@ -22,7 +22,7 @@ FILES_${PN} = " \
 
 SYSTEMD_SERVICE_${PN} = "dom0-block-device.service"
 
-RDEPENDS_${PN} = "systemd bash"
+RDEPENDS_${PN} = "systemd bash backend-ready"
 
 do_install() {
     install -d ${D}${systemd_system_unitdir}

--- a/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-extended/dom0-block-device/files/dom0-block-device.service
+++ b/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-extended/dom0-block-device/files/dom0-block-device.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Dom0 block device
-Requires=domd.service
-After=domd.service
+Requires=domd.service backend-ready@block.service
+After=domd.service backend-ready@block.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Dom0 block device should be attached and mounted after block backend is ready.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>