### PR TITLE
linux-generic-armv8: Add fixes to the pvcalls-back driver

### DIFF
--- a/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8.bbappend
+++ b/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+    file://0001-xen-pvcalls-back-fix-permanently-masked-event-channe.patch \
+    file://0001-xen-pvcalls-free-active-map-buffer-on-pvcalls_front_.patch \
+"

--- a/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8/0001-xen-pvcalls-back-fix-permanently-masked-event-channe.patch
+++ b/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8/0001-xen-pvcalls-back-fix-permanently-masked-event-channe.patch
@@ -1,0 +1,48 @@
+From acb6cd9b546097b19a76244751c65ecb7e18066d Mon Sep 17 00:00:00 2001
+Message-Id: <acb6cd9b546097b19a76244751c65ecb7e18066d.1674208804.git.oleksii_moisieiev@epam.com>
+From: Volodymyr Babchuk <Volodymyr_Babchuk@epam.com>
+Date: Thu, 19 Jan 2023 21:11:15 +0000
+Subject: [PATCH] xen/pvcalls-back: fix permanently masked event channel
+
+There is a sequence of events that can lead to a permanently masked
+event channel, because xen_irq_lateeoi() is newer called. This happens
+when a backend receives spurious write event from a frontend. In this
+case pvcalls_conn_back_write() returns early and it does not clears the
+map->write counter. As map->write > 0, pvcalls_back_ioworker() returns
+without calling xen_irq_lateeoi(). This leaves the event channel in
+masked state, a backend does not receive any new events from a
+frontend and the whole communication stops.
+
+Move atomic_set(&map->write, 0) to the very beginning of
+pvcalls_conn_back_write() to fix this issue.
+
+Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>
+Reported-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
+---
+ drivers/xen/pvcalls-back.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/xen/pvcalls-back.c b/drivers/xen/pvcalls-back.c
+index a7d293fa8d14..60f5cd70d770 100644
+--- a/drivers/xen/pvcalls-back.c
++++ b/drivers/xen/pvcalls-back.c
+@@ -173,6 +173,8 @@ static bool pvcalls_conn_back_write(struct sock_mapping *map)
+ 	RING_IDX cons, prod, size, array_size;
+ 	int ret;
+ 
++	atomic_set(&map->write, 0);
++
+ 	cons = intf->out_cons;
+ 	prod = intf->out_prod;
+ 	/* read the indexes before dealing with the data */
+@@ -197,7 +199,6 @@ static bool pvcalls_conn_back_write(struct sock_mapping *map)
+ 		iov_iter_kvec(&msg.msg_iter, READ, vec, 2, size);
+ 	}
+ 
+-	atomic_set(&map->write, 0);
+ 	ret = inet_sendmsg(map->sock, &msg, size);
+ 	if (ret == -EAGAIN) {
+ 		atomic_inc(&map->write);
+-- 
+2.25.1
+

--- a/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8/0001-xen-pvcalls-free-active-map-buffer-on-pvcalls_front_.patch
+++ b/meta-aos-rcar-common/meta-aos-rcar-common-dom0/recipes-kernel/linux/linux-generic-armv8/0001-xen-pvcalls-free-active-map-buffer-on-pvcalls_front_.patch
@@ -1,0 +1,42 @@
+From a717dac5ed6aa06fd67fe9f33bf38fcc3dea1b30 Mon Sep 17 00:00:00 2001
+Message-Id: <a717dac5ed6aa06fd67fe9f33bf38fcc3dea1b30.1674215656.git.oleksii_moisieiev@epam.com>
+From: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
+Date: Thu, 8 Dec 2022 09:10:50 +0200
+Subject: [PATCH] xen/pvcalls: free active map buffer on pvcalls_front_free_map
+
+Data buffer for active map is allocated in alloc_active_ring and freed
+in free_active_ring function, which is used only for the error
+cleanup. pvcalls_front_release is calling pvcalls_front_free_map which
+ends foreign access for this buffer, but doesn't free allocated pages.
+Call free_active_ring to clean all allocated resources.
+
+Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>
+---
+ drivers/xen/pvcalls-front.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/xen/pvcalls-front.c b/drivers/xen/pvcalls-front.c
+index 7984645b5956..48aa43f7a639 100644
+--- a/drivers/xen/pvcalls-front.c
++++ b/drivers/xen/pvcalls-front.c
+@@ -225,6 +225,8 @@ static irqreturn_t pvcalls_front_event_handler(int irq, void *dev_id)
+ 	return IRQ_HANDLED;
+ }
+ 
++static void free_active_ring(struct sock_mapping *map);
++
+ static void pvcalls_front_free_map(struct pvcalls_bedata *bedata,
+ 				   struct sock_mapping *map)
+ {
+@@ -240,7 +242,7 @@ static void pvcalls_front_free_map(struct pvcalls_bedata *bedata,
+ 	for (i = 0; i < (1 << PVCALLS_RING_ORDER); i++)
+ 		gnttab_end_foreign_access(map->active.ring->ref[i], 0, 0);
+ 	gnttab_end_foreign_access(map->active.ref, 0, 0);
+-	free_page((unsigned long)map->active.ring);
++	free_active_ring(map);
+ 
+ 	kfree(map);
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
Add fixes that are fixing the logic on the pvcalls-back driver. This will allow pvcalls to work correctly with unikernels.

Signed-off-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>