### PR TITLE
[gen3] Kernel set max_vcpus = 2 to gen3 board as it is on gen4

### DIFF
--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/xen-chosen.dtsi
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/xen-chosen.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "dom0_mem=1024M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=info sched_ratelimit_us=100 hmp-unsafe=true xsm=dummy console_timestamps=boot";
+		bootargs = "dom0_mem=1024M console=dtuart dtuart=serial0 dom0_max_vcpus=2 bootscrub=0 loglvl=info sched_ratelimit_us=100 hmp-unsafe=true xsm=dummy console_timestamps=boot";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		/delete-property/stdout-path;
 		modules {


### PR DESCRIPTION
Changed to 2 as it was configured for Spider.