### PR TITLE
[yaml] Fix build for h3ulcb-4x2g-kf board

### DIFF
--- a/aos-rcar-demo2023.yaml
+++ b/aos-rcar-demo2023.yaml
@@ -503,7 +503,7 @@ parameters:
           GEN3_ZEPHYR_DOM0_MACHINE: "rcar_h3ulcb_ca57"
 
         components:
-          domd:
+          gen3-domd:
             sources:
               - type: git
                 url: "https://github.com/CogentEmbedded/meta-rcar.git"
@@ -516,7 +516,7 @@ parameters:
                 # Ignore OP-TEE patches as we have own OP-TEE
                 - [BBMASK_append, " meta-rcar-gen3-adas/recipes-bsp/optee"]
 
-        images:
+        gen3_full:
           full:
             partitions:
               domd_rootfs:


### PR DESCRIPTION
We have changed labels of domd and image because this build includes complex configuration with 2 boards: gen4 and gen3. So the labels are made to be specifically related to gen3 or gen4 board as well as images.