### PR TITLE
domd: disable MMC

### DIFF
--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-dom0/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-dom0/recipes-guests/domd/files/domd-salvator-xs-m3-2x4g.cfg
@@ -99,7 +99,6 @@ dtdev = [
     "/soc/usb@ee0a0000",
     "/soc/usb@ee0a0100",
     "/soc/mmc@ee100000",
-    "/soc/mmc@ee140000",
     "/soc/mmc@ee160000",
     "/soc/fdpm@fe940000",
     "/soc/vspm@fe960000",
@@ -203,8 +202,6 @@ irqs = [
     144,
 # mmc@ee100000
     197,
-# mmc@ee140000
-    199,
 # mmc@ee160000
     200,
 # src-0
@@ -407,8 +404,6 @@ iomem = [
     "ee0a0,1",
 #mmc@ee100000
     "ee100,2",
-#mmc@ee140000
-    "ee140,2",
 #mmc@ee160000
     "ee160,2",
 #sound@ec500000

--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-domd.dts
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-domd.dts
@@ -62,3 +62,7 @@
 &sound_card {
 	dais = <&rsnd_port0>; /* ak4613 */
 };
+
+&sdhi2 {
+	status = "disabled";
+};

--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-xen.dts
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/r8a77961-salvator-xs-2x4g-xen.dts
@@ -342,7 +342,6 @@
 &rpc0			{ xen,passthrough; };
 &hscif1			{ xen,passthrough; };
 &sdhi0			{ xen,passthrough; };
-&sdhi2			{ xen,passthrough; };
 &sdhi3			{ xen,passthrough; };
 &scif1			{ xen,passthrough; };
 &src0			{ xen,passthrough; };

--- a/meta-aos-rcar-gen4/meta-aos-rcar-gen4-domd/recipes-kernel/linux/linux-renesas/0001-clk-sdhi-Disable-sdhi-clocks.patch
+++ b/meta-aos-rcar-gen4/meta-aos-rcar-gen4-domd/recipes-kernel/linux/linux-renesas/0001-clk-sdhi-Disable-sdhi-clocks.patch
@@ -1,0 +1,40 @@
+From 9df019cd518090f618317de0e9b4940a1bb307a1 Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Fri, 16 Jun 2023 16:38:10 +0300
+Subject: [PATCH] clk:sdhi Disable sdhi clocks
+
+MMC is used in zephyr Dom0, so disable it's clocks to prevent domd from
+messing them up.
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ drivers/clk/renesas/r8a779f0-cpg-mssr.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/clk/renesas/r8a779f0-cpg-mssr.c b/drivers/clk/renesas/r8a779f0-cpg-mssr.c
+index 1cc62bc5effe..014090276602 100644
+--- a/drivers/clk/renesas/r8a779f0-cpg-mssr.c
++++ b/drivers/clk/renesas/r8a779f0-cpg-mssr.c
+@@ -113,7 +113,9 @@ static const struct cpg_core_clk r8a779f0_core_clks[] __initconst = {
+ 	DEF_FIXED("sasyncperd2", R8A779F0_CLK_SASYNCPERD2, R8A779F0_CLK_SASYNCPER, 2, 1),
+ 	DEF_FIXED("sasyncperd4", R8A779F0_CLK_SASYNCPERD4, R8A779F0_CLK_SASYNCPER, 4, 1),
+ 
++#ifndef CONFIG_XEN
+ 	DEF_GEN4_SD("sd0",	R8A779F0_CLK_SD0,	CLK_SDSRC,	0x870),
++#endif
+ 	DEF_DIV6P1("mso",       R8A779F0_CLK_MSO,       CLK_PLL5_DIV4, 0x087C),
+ 
+ 	DEF_GEN4_OSC("osc",	R8A779F0_CLK_OSC,	CLK_EXTAL,	8),
+@@ -149,7 +151,9 @@ static const struct mssr_mod_clk r8a779f0_mod_clks[] __initconst = {
+ 	DEF_MOD("scif3",	704,	R8A779F0_CLK_SASYNCPERD4),
+ #endif
+ 	DEF_MOD("scif4",	705,	R8A779F0_CLK_SASYNCPERD4),
++#ifndef CONFIG_XEN
+ 	DEF_MOD("sdhi0",	706,	R8A779F0_CLK_SD0),
++#endif
+ 	DEF_MOD("sydm1",	709,	R8A779F0_CLK_S0D3),
+ 	DEF_MOD("sydm2",	710,	R8A779F0_CLK_S0D3),
+ 	DEF_MOD("tmu0",		713,	R8A779F0_CLK_S0D6_RT),
+-- 
+2.34.1
+

--- a/meta-aos-rcar-gen4/meta-aos-rcar-gen4-domd/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-aos-rcar-gen4/meta-aos-rcar-gen4-domd/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -24,6 +24,7 @@ SRC_URI_append = " \
     file://0003-HACK-Allow-DomD-enumerate-PCI-devices.patch \
     file://0004-HACK-pcie-renesas-emulate-reading-from-ECAM-under-Xe.patch \
     file://0001-xen-blkback-update-persistent-grants-enablement-logi.patch \
+    file://0001-clk-sdhi-Disable-sdhi-clocks.patch \
 "
 
 ADDITIONAL_DEVICE_TREES = "${XT_DEVICE_TREES}"


### PR DESCRIPTION
Now when domd supports boot from SD we can safely move eMMC controller to dom0 to serve as secure, privileged storage.