### PR TITLE
[gen3] domd: Add patch to disable mmc clocks

### DIFF
--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/0001-clk-sdhi-Disable-sdhi-clocks.patch
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/files/0001-clk-sdhi-Disable-sdhi-clocks.patch
@@ -1,0 +1,40 @@
+From 1af6b5f01277c3ed3beccc275310f3517a236c9c Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Tue, 27 Jun 2023 13:10:15 +0300
+Subject: [PATCH] clk:sdhi Disable sdhi clocks
+
+MMC is used in zephyr Dom0, so disable it's clocks to prevent domd from
+messing them up.
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ drivers/clk/renesas/r8a7796-cpg-mssr.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/clk/renesas/r8a7796-cpg-mssr.c b/drivers/clk/renesas/r8a7796-cpg-mssr.c
+index 1fc2e659372e..9759c2d2ea8f 100644
+--- a/drivers/clk/renesas/r8a7796-cpg-mssr.c
++++ b/drivers/clk/renesas/r8a7796-cpg-mssr.c
+@@ -109,7 +109,9 @@ static const struct cpg_core_clk r8a7796_core_clks[] __initconst = {
+ 
+ 	DEF_GEN3_SD("sd0",      R8A7796_CLK_SD0,   CLK_SDSRC,     0x074),
+ 	DEF_GEN3_SD("sd1",      R8A7796_CLK_SD1,   CLK_SDSRC,     0x078),
++#ifndef CONFIG_XEN
+ 	DEF_GEN3_SD("sd2",      R8A7796_CLK_SD2,   CLK_SDSRC,     0x268),
++#endif
+ 	DEF_GEN3_SD("sd3",      R8A7796_CLK_SD3,   CLK_SDSRC,     0x26c),
+ 
+ 	DEF_FIXED("cl",         R8A7796_CLK_CL,    CLK_PLL1_DIV2, 48, 1),
+@@ -154,7 +156,9 @@ static struct mssr_mod_clk r8a7796_mod_clks[] __initdata = {
+ 	DEF_MOD("tpu0",			 304,	R8A7796_CLK_S3D4),
+ 	/*DEF_MOD("scif2",		 310,	R8A7796_CLK_S3D4),*/
+ 	DEF_MOD("sdif3",		 311,	R8A7796_CLK_SD3),
++#ifndef CONFIG_XEN
+ 	DEF_MOD("sdif2",		 312,	R8A7796_CLK_SD2),
++#endif
+ 	DEF_MOD("sdif1",		 313,	R8A7796_CLK_SD1),
+ 	DEF_MOD("sdif0",		 314,	R8A7796_CLK_SD0),
+ 	DEF_MOD("pcie1",		 318,	R8A7796_CLK_S3D1),
+-- 
+2.34.1
+

--- a/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-aos-rcar-gen3/meta-aos-rcar-gen3-domd/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -3,6 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI_append = " \
     file://defconfig \
     file://0001-xen-blkback-update-persistent-grants-enablement-logi.patch \
+    file://0001-clk-sdhi-Disable-sdhi-clocks.patch \
     file://xen-chosen.dtsi;subdir=git/arch/${ARCH}/boot/dts/renesas \
     file://aos.cfg \
 "


### PR DESCRIPTION
DomD messes MMC clocks when it starts, so disable them.